### PR TITLE
Migrate to Ruby 3

### DIFF
--- a/lib/sidekiq/delay_extensions/class_methods.rb
+++ b/lib/sidekiq/delay_extensions/class_methods.rb
@@ -15,8 +15,15 @@ module Sidekiq
     class DelayedClass
       include Sidekiq::Worker
 
+      DEFAULT_PERMITTED_CLASSES = [Symbol, Date]
+
+      def self.permitted_classes=(arr); @permitted_classes = arr; end
+      def self.permitted_classes;       @permitted_classes || DEFAULT_PERMITTED_CLASSES; end
+
       def perform(yml)
-        (target, method_name, args, kwargs) = ::YAML.safe_load(yml, permitted_classes: [Symbol])
+        (target, method_name, args, kwargs) = ::YAML.safe_load(
+          yml, permitted_classes: self.class.permitted_classes
+        )
         target.__send__(method_name, *args, **kwargs.to_h)
       end
     end

--- a/lib/sidekiq/delay_extensions/class_methods.rb
+++ b/lib/sidekiq/delay_extensions/class_methods.rb
@@ -17,7 +17,7 @@ module Sidekiq
 
       def perform(yml)
         (target, method_name, args, kwargs) = ::YAML.safe_load(yml, permitted_classes: [Symbol])
-        target.__send__(method_name, *args, **kwargs)
+        target.__send__(method_name, *args, **kwargs.to_h)
       end
     end
 

--- a/lib/sidekiq/delay_extensions/class_methods.rb
+++ b/lib/sidekiq/delay_extensions/class_methods.rb
@@ -16,8 +16,8 @@ module Sidekiq
       include Sidekiq::Worker
 
       def perform(yml)
-        (target, method_name, args) = YAML.load(yml)
-        target.__send__(method_name, *args)
+        (target, method_name, args, kwargs) = ::YAML.safe_load(yml, permitted_classes: [Symbol])
+        target.__send__(method_name, *args, **kwargs)
       end
     end
 

--- a/lib/sidekiq/delay_extensions/generic_proxy.rb
+++ b/lib/sidekiq/delay_extensions/generic_proxy.rb
@@ -13,13 +13,13 @@ module Sidekiq
         @opts = options
       end
 
-      def method_missing(name, *args)
+      def method_missing(name, *args, **kwargs)
         # Sidekiq has a limitation in that its message must be JSON.
         # JSON can't round trip real Ruby objects so we use YAML to
         # serialize the objects to a String.  The YAML will be converted
         # to JSON and then deserialized on the other side back into a
         # Ruby object.
-        obj = [@target, name, args]
+        obj = [@target, name, args, kwargs]
         marshalled = ::YAML.dump(obj)
         if marshalled.size > SIZE_LIMIT
           ::Sidekiq.logger.warn { "#{@target}.#{name} job argument is #{marshalled.bytesize} bytes, you should refactor it to reduce the size" }


### PR DESCRIPTION
Remember and transfer not only `*args`, but also `**kwargs`.
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Code to reproduce error:

```ruby
# Ruby 3.1
require 'sidekiq/testing/inline'

class Test
  def self.test(a, options: {})
    puts("a: #{a}")
    puts("options: #{options}")
  end
end

Test.test(1, options: {a: 2})
# a: 1
# options: {:a=>2}

Test.delay.test(1, options: {a: 2})
# raise error:
# `test': wrong number of arguments (given 2, expected 1) (ArgumentError)

# With fix:
Test.delay.test(1, options: {a: 2})
# a: 1
# options: {:a=>2}
# "549e36bc1a16f8964d44afda"
```