### PR TITLE
CI: modernize build matrix, keep in-support Ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1"]
+        ruby: ["3.0", "3.1", "3.2"]
     services:
       redis:
         image: redis


### PR DESCRIPTION
This PR drops out-of-support Ruby versions from the testing matrix, and adds Ruby 3.2.