### PR TITLE
Restore 4-tuple kwargs payload

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,70 @@
 Unreleased
 ---------
 
+7.2.0
+---------
+
+### ⚠️ Visible behaviour changes — read before upgrading
+
+1. **Wire-format change:** the YAML payload emitted for every `delay` /
+   `delay_for` / `delay_until` call is now a 4-tuple
+   `[target, method_name, positional_args, kwargs]` instead of a 3-tuple.
+   This restores the format that Sidekiq 6.4's built-in delay extension
+   always produced.  Jobs enqueued by 7.0–7.1 (3-tuple) are still dispatched
+   correctly with no new exceptions — see the migration section in the
+   README.
+
+2. **`Sidekiq::JobRecord#display_args` format change for delay jobs:** when
+   keyword arguments are present, `display_args` now returns
+   `[positional_args, kwargs_hash]` instead of a flat merged array.  This
+   restores the structured separation that the gem's `api.rb` was always
+   written for.  If you have custom Web UI extensions, log scrapers, or
+   observability tooling that read `display_args` for delay jobs, update
+   those consumers — see the README "`display_args` format change" section
+   for examples.
+
+   ```ruby
+   # 7.1.0 (3-tuple, kwargs merged into positional)
+   job.display_args  #=> ["alice@example.com", {locale: :en}]
+
+   # 7.2.0+ (4-tuple, structured separation)
+   job.display_args  #=> [["alice@example.com"], {locale: :en}]
+   ```
+
+### Fix
+
+- **`Proxy` now emits a 4-tuple YAML payload matching Sidekiq 6.4 semantics.**
+
+  Prior to this release, `Proxy#method_missing` was declared as
+  `def method_missing(name, *args)` — missing the `**kwargs` parameter.  On
+  Ruby 3.1+ keyword arguments no longer auto-convert from a trailing positional
+  Hash, so a call like `User.delay.call("1", locale: :en)` collapsed the
+  `{locale: :en}` hash into `*args` instead of capturing it separately.  The
+  resulting 3-tuple YAML payload (`[target, method, args_with_folded_kwargs]`)
+  lost all kwargs information, causing `ArgumentError` on dispatch for any
+  method with named keyword parameters.  See discussion
+  [sidekiq#6979](https://github.com/sidekiq/sidekiq/discussions/6979).
+
+  The fix restores the signature to `def method_missing(name, *args, **kwargs)`
+  and emits a 4-tuple `[target, method_name, positional_args, kwargs]` —
+  identical to the layout that Sidekiq 6.4's built-in delay extension always
+  produced.  `GenericJob#perform` is updated to destructure all four slots and
+  re-splat kwargs explicitly on dispatch.
+
+### Backward compatibility
+
+  Jobs already sitting in your queue / retry set / scheduled set at deploy
+  time use the old 3-tuple format.  `GenericJob#perform` handles those
+  gracefully: the missing kwargs slot is treated as an empty Hash, producing
+  the same dispatch behaviour as before 7.2.0 (no new exceptions introduced).
+  See the README migration section for guidance on draining or replaying
+  affected jobs.
+
+### Unchanged
+
+- `GenericProxy` (`use_generic_proxy = true`) is unchanged; it already handled
+  kwargs via its own JSON serialisation path.
+
 7.1.0
 ---------
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,131 @@ Version 7.x of this gem will maintain compatibility with Sidekiq 7.x.
 
 This gem is maintained independent of Sidekiq. Maintainers wanted.
 
+Migrating from Sidekiq 6 to 7 (kwargs fix)
+-----------------
+
+If you are upgrading from Sidekiq 6 (which had delay extensions built-in) to
+Sidekiq 7 + this gem, ensure you are on **7.2.0 or later**.
+
+### What broke and why
+
+Sidekiq 6.4's built-in `Proxy` serialised every delay call as a **4-tuple**:
+
+```yaml
+- !ruby/class 'User'
+- :send_welcome
+- ["alice@example.com"]   # positional args
+- :locale: :en             # kwargs — always in their own slot
+```
+
+Versions 7.0.0–7.1.x of this gem regressed to a **3-tuple** because
+`Proxy#method_missing` lacked the `**kwargs` parameter.  On Ruby 3.1+ keyword
+arguments are no longer auto-promoted from a trailing positional Hash, so
+
+```ruby
+User.delay.send_welcome("alice@example.com", locale: :en)
+```
+
+produced `{locale: :en}` folded into `*args` instead:
+
+```yaml
+- !ruby/class 'User'
+- :send_welcome
+- ["alice@example.com", {locale: :en}]   # 3-tuple — kwargs lost!
+```
+
+On dispatch, `GenericJob#perform` called `target.__send__(method, *args)` which
+passed the hash as a positional argument and raised
+`ArgumentError: wrong number of arguments` for any method with named keywords.
+
+### Fix (7.2.0+)
+
+`Proxy#method_missing` is restored to `def method_missing(name, *args, **kwargs)`
+and the 4-tuple payload format is re-established.  `GenericJob#perform`
+destructures all four slots and re-splats kwargs correctly.
+
+### Handling jobs already in the queue at deploy time
+
+Jobs enqueued before the upgrade (3-tuple format) will still be in your queue,
+retry set, and scheduled set when you deploy 7.2.0.  `GenericJob#perform`
+treats the missing kwargs slot as an empty `{}` — the same no-kwargs dispatch
+path as before — so **no new exceptions are introduced for those jobs**.
+
+However, because the kwargs were folded into positional args at enqueue time,
+they cannot be recovered retroactively.  Those jobs will continue to fail (as
+they did on the old version) for methods that require keyword arguments.
+
+**Recommended approach for the transition window:**
+
+1. Deploy 7.2.0.  All *new* delay calls from this point forward are correct.
+2. Drain or discard any existing 3-tuple jobs that call methods with required
+   kwargs (they were already failing, so discarding them is safe).
+3. Over the following days, the retry / scheduled sets will naturally empty out
+   as those jobs exhaust their retries.
+
+If you need zero downtime and cannot tolerate the failure window, enqueue a
+migration job before deploying that moves affected jobs out of the retry/dead
+sets, or use a Sidekiq server middleware to detect and re-enqueue the 3-tuple
+payloads with corrected kwargs (see the discussion in
+[#6979](https://github.com/sidekiq/sidekiq/discussions/6979)).
+
+### `display_args` format change
+
+When kwargs are present, `Sidekiq::JobRecord#display_args` now returns
+`[positional_args, kwargs_hash]` instead of a flat merged array:
+
+```ruby
+# Before 7.2.0 (3-tuple, kwargs merged into positional)
+job.display_args  #=> ["alice@example.com", {locale: :en}]
+
+# 7.2.0+ (4-tuple, structured separation)
+job.display_args  #=> [["alice@example.com"], {locale: :en}]
+```
+
+If your code inspects `display_args` directly (e.g. in custom Web UI
+extensions, log scrapers, or observability tooling), update those consumers
+accordingly.
+
+### Ruby version sensitivity
+
+The gem records whatever Ruby's calling convention puts in `*args` vs
+`**kwargs` at the call site.  Ruby 3.0 changed this convention — a trailing
+positional `Hash` is no longer auto-promoted to keyword arguments.  So the
+*same source line* produces a different payload (and a different dispatch
+shape) depending on the Ruby version:
+
+```ruby
+KwargsTarget.delay.foo({color: :blue})
+
+# Ruby 2.7  (auto-promotes, deprecation warning):
+#   payload = [KwargsTarget, :foo, [],                {color: :blue}]
+# Ruby 3.0+ (separation enforced):
+#   payload = [KwargsTarget, :foo, [{color: :blue}],  {}]
+```
+
+This is Ruby's behaviour, not the gem's, but worth being aware of when
+upgrading Ruby alongside the gem.  **Avoid the literal-Hash-as-positional
+form** (`delay.foo({color: :blue})`) because the intent is ambiguous across
+Ruby versions.  Use:
+
+- `delay.foo(color: :blue)` — explicit kwargs, identical on every Ruby.
+- `delay.foo(opts)` where `opts = {color: :blue}` is a local variable and
+  the target method declares a positional Hash parameter — explicit
+  positional, identical on every Ruby.
+
+A useful side effect of Ruby 2.7's auto-promotion: legacy 3-tuple payloads
+enqueued by gem 7.0–7.1 actually *recover* their kwargs at dispatch time on
+Ruby 2.7 (the language splat re-routes the folded Hash into `**kwargs` for
+us).  On Ruby 3.0+, those payloads dispatch identically to pre-7.2.0 — the
+Hash stays positional, no new exceptions.
+
+### Other Sidekiq plugins (Pro, Cron, unique-jobs, alive)
+
+Sidekiq Pro, sidekiq-cron, sidekiq-unique-jobs, and sidekiq_alive treat the
+delay job's `args[0]` as an opaque marshalled string — they do not parse the
+YAML payload themselves.  This change is therefore transparent to those
+plugins and requires no coordinated upgrade.
+
 Requirements
 -----------------
 

--- a/lib/sidekiq/delay_extensions/generic_job.rb
+++ b/lib/sidekiq/delay_extensions/generic_job.rb
@@ -7,8 +7,14 @@ module Sidekiq
 
       def perform(yml)
         if !Sidekiq::DelayExtensions.use_generic_proxy
-          (target, method_name, args) = ::Sidekiq::DelayExtensions::YAML.unsafe_load(yml)
-          return _perform(target, method_name, *args)
+          (target, method_name, args, kwargs) = ::Sidekiq::DelayExtensions::YAML.unsafe_load(yml)
+          # kwargs is nil for 3-tuple payloads enqueued by older versions of this gem
+          # (prior to 7.2.0) or by any code that did not emit the 4th slot. Treat
+          # them as having no kwargs so dispatch is identical to the old behaviour —
+          # no regression for jobs already sitting in the queue, retry set, or
+          # scheduled set at deploy time.
+          kwargs ||= {}
+          return kwargs.empty? ? _perform(target, method_name, *args) : _perform(target, method_name, *args, **kwargs)
         end
         (target, method_name, args, kwargs) = ::Sidekiq::DelayExtensions::YAML.unsafe_load(yml)
         if target.is_a?(String)

--- a/lib/sidekiq/delay_extensions/generic_proxy.rb
+++ b/lib/sidekiq/delay_extensions/generic_proxy.rb
@@ -16,13 +16,18 @@ module Sidekiq
         @opts = options.transform_keys(&:to_s)
       end
 
-      def method_missing(name, *args)
+      def method_missing(name, *args, **kwargs)
         # Sidekiq has a limitation in that its message must be JSON.
         # JSON can't round trip real Ruby objects so we use YAML to
         # serialize the objects to a String.  The YAML will be converted
         # to JSON and then deserialized on the other side back into a
         # Ruby object.
-        obj = [@target, name, args]
+        #
+        # Payload is a 4-tuple: [target, method_name, positional_args, kwargs].
+        # The kwargs slot is always present (empty Hash when no kwargs), which
+        # matches the layout that Sidekiq 6.4's built-in delay produced and lets
+        # GenericJob#perform re-splat them correctly on Ruby 3.1+.
+        obj = [@target, name, args, kwargs]
         marshalled = ::YAML.dump(obj)
         if marshalled.size > SIZE_LIMIT
           ::Sidekiq.logger.warn { "#{@target}.#{name} job argument is #{marshalled.bytesize} bytes, you should refactor it to reduce the size" }

--- a/lib/sidekiq/delay_extensions/version.rb
+++ b/lib/sidekiq/delay_extensions/version.rb
@@ -2,6 +2,6 @@
 
 module Sidekiq
   module DelayExtensions
-    VERSION = "7.1.0"
+    VERSION = "7.2.0"
   end
 end

--- a/test/kwargs_proxy_test.rb
+++ b/test/kwargs_proxy_test.rb
@@ -19,27 +19,34 @@
 #
 # Coverage in this file
 # ---------------------
-#  1.  Proxy payload shape  — 4-tuple emitted for delay / delay_for / delay_until
-#  2.  Payload slots         — target, method, args, kwargs each in the right slot
-#  3.  Edge cases            — kwargs-only, positional-only, positional Hash ≠ kwargs
-#  4.  Module target         — Proxy works on plain modules, not just classes
-#  5.  YAML symbol round-trip — kwargs keys survive serialisation as symbols
-#  6.  GenericJob dispatch   — perform re-splats kwargs correctly from 4-tuple
-#  7.  dispatch_class        — display_class is correct with 4-tuple payload
-#  8.  display_args          — positional/kwargs shown separately when kwargs present
-#  9.  Full round-trip        — enqueue via Proxy, execute inline via GenericJob
-# 10.  DelayedModel          — all three job subclasses exercised
-# 11.  DelayedMailer         — mailer 4-tuple emission + dispatch without ArgumentError
-# 12.  Sidekiq 6.4 compat    — exact 4-tuple YAML from the old built-in dispatches OK
-# 13.  Regression scenario   — exact broken call from discussion #6979
-# 14.  Backward compat       — legacy 3-tuple payloads dispatched without new exceptions
-# 15.  GenericProxy unchanged — use_generic_proxy=true path is unaffected
+#  1. Proxy payload shape — .delay
+#  2. Proxy payload shape — .delay_for and .delay_until
+#  3. Module target (non-class)
+#  4. YAML symbol key round-trip
+#  5. GenericJob#perform dispatch from 4-tuple
+#  6. display_class with 4-tuple
+#  7. display_args with 4-tuple
+#  8. Full round-trip (Proxy → inline GenericJob)
+#  9. DelayedModel — class-method and AR-instance-method paths
+# 10. DelayedMailer — emission + dispatch with captured kwargs assertion
+# 11. Sidekiq 6.4 built-in payload compatibility (real migration scenario)
+# 12. Regression — discussion #6979 exact repro
+# 13. Backward compatibility — legacy 3-tuple payloads (no new exceptions)
+# 14. GenericProxy (use_generic_proxy=true) is unaffected
 
 require_relative "helper"
 require "sidekiq/api"
 require "active_record"
 require "action_mailer"
 Sidekiq::DelayExtensions.enable_delay!
+
+# Use the in-memory :test delivery method so KwargsMailer dispatch tests don't
+# try to open an SMTP connection.  Captured deliveries land in
+# ActionMailer::Base.deliveries which we ignore — the assertions inspect
+# captured kwargs directly.
+ActionMailer::Base.delivery_method = :test
+ActionMailer::Base.perform_deliveries = true
+ActionMailer::Base.raise_delivery_errors = false
 
 # ---------------------------------------------------------------------------
 # Support classes
@@ -56,6 +63,10 @@ class KwargsTarget
 
   def self.positional_only(a, b)
     a + b
+  end
+
+  def self.no_args
+    :called_without_args
   end
 
   # A positional Hash parameter — must NOT be treated as kwargs at enqueue time.
@@ -81,15 +92,37 @@ module KwargsModule
 end
 
 class KwargsMailer < ActionMailer::Base
+  # Mutable capture slot for assertions in dispatch tests — see test #10.
+  cattr_accessor :captured_args, instance_accessor: false
+  self.captured_args = nil
+
   def welcome(name:, locale: :en)
-    name
+    KwargsMailer.captured_args = {name: name, locale: locale}
+    # Build a real (test-mode) Mail::Message so the surrounding _perform's
+    # `msg.deliver_now` call is a no-op via ActionMailer's :test delivery.
+    mail(to: "to@test.invalid", from: "from@test.invalid", subject: "ok", body: "ok")
   end
 end
 
-# Minimal AR-like class for DelayedModel tests (avoids sqlite3 setup)
+# Minimal AR-like class for DelayedModel CLASS-method tests (avoids sqlite3 setup).
 class KwargsRecord
   def self.process(entity_id, action:, priority: :normal)
     [entity_id, action, priority]
+  end
+end
+
+# AR-style INSTANCE delay path: include the same module that
+# Sidekiq::DelayExtensions wires onto ActiveRecord::Base in production.
+# This exercises the user_instance.delay.method(kwarg: val) flow without
+# requiring a real database connection.
+class KwargsActiveModel
+  include Sidekiq::DelayExtensions::ActiveRecord
+
+  cattr_accessor :received, instance_accessor: false
+  self.received = nil
+
+  def update_with(new_status:, audited_by: :system)
+    KwargsActiveModel.received = {new_status: new_status, audited_by: audited_by}
   end
 end
 
@@ -97,10 +130,17 @@ end
 # YAML helpers
 # ---------------------------------------------------------------------------
 
-# 3-tuple YAML as the broken 7.1.0 Proxy emitted on Ruby 3.1 when called with
-# keyword arguments — kwargs are folded as a trailing element of *args.
-def legacy_3tuple_yml(target, method_sym, positional_args, kwargs_hash)
+# 3-tuple YAML matching what the broken 7.1.0 Proxy actually emitted on Ruby
+# 3.1 when called with keyword arguments — kwargs end up folded as a trailing
+# Hash inside the *args array (because **kwargs was missing from the proxy).
+def legacy_3tuple_with_folded_kwargs(target, method_sym, positional_args, kwargs_hash)
   ::YAML.dump([target, method_sym, positional_args + [kwargs_hash]])
+end
+
+# 3-tuple YAML for a no-kwargs legacy call (what 7.1.0 emitted when no kwargs
+# were passed at all — args is just the bare positional array).
+def legacy_3tuple_positional_only(target, method_sym, positional_args)
+  ::YAML.dump([target, method_sym, positional_args])
 end
 
 # 4-tuple YAML as the fixed 7.2.0 Proxy (and Sidekiq 6.4 built-in) emits.
@@ -116,6 +156,8 @@ describe "Proxy kwargs fix (4-tuple payload)" do
   before do
     @cfg = reset!
     Sidekiq::DelayExtensions.use_generic_proxy = false
+    KwargsMailer.captured_args = nil
+    KwargsActiveModel.received = nil
   end
 
   after do
@@ -123,7 +165,7 @@ describe "Proxy kwargs fix (4-tuple payload)" do
   end
 
   # =========================================================================
-  # 1–4. Proxy payload shape
+  # 1. Proxy payload shape — .delay
   # =========================================================================
 
   describe "Proxy payload shape — .delay" do
@@ -147,6 +189,17 @@ describe "Proxy kwargs fix (4-tuple payload)" do
       assert_equal({}, raw[3])
     end
 
+    it "emits a 4-tuple for a no-args, no-kwargs call" do
+      q = Sidekiq::Queue.new
+      KwargsTarget.delay.no_args
+      raw = ::YAML.unsafe_load(q.first["args"].first)
+      assert_equal 4, raw.length
+      assert_equal KwargsTarget, raw[0]
+      assert_equal :no_args, raw[1]
+      assert_equal [], raw[2]
+      assert_equal({}, raw[3])
+    end
+
     it "emits kwargs-only as [] args + kwargs hash" do
       q = Sidekiq::Queue.new
       KwargsTarget.delay.kwargs_only(name: "alice", value: 42)
@@ -155,14 +208,31 @@ describe "Proxy kwargs fix (4-tuple payload)" do
       assert_equal({name: "alice", value: 42}, raw[3])
     end
 
-    it "does not conflate a positional Hash with kwargs" do
+    it "preserves Ruby's own positional/kwargs split for a literal trailing Hash" do
+      # The gem records whatever Ruby's calling convention puts in *args vs
+      # **kwargs at the Proxy.method_missing call site.  Ruby itself differs
+      # between versions for a literal trailing Hash:
+      #   - Ruby 2.7  → auto-promotes the Hash to **kwargs (deprecation warning)
+      #   - Ruby 3.0+ → keeps the Hash in *args (kwargs separation enforced)
+      # Both outcomes are correct for the gem; this test asserts whichever is
+      # appropriate for the running Ruby.  See README "Ruby version sensitivity".
       q = Sidekiq::Queue.new
       KwargsTarget.delay.positional_hash({color: :blue})
       raw = ::YAML.unsafe_load(q.first["args"].first)
-      assert_equal [{color: :blue}], raw[2], "positional hash must stay in args slot"
-      assert_equal({}, raw[3], "kwargs slot must be empty")
+      assert_equal 4, raw.length, "payload is always a 4-tuple regardless of Ruby version"
+      if RUBY_VERSION >= "3.0"
+        assert_equal [{color: :blue}], raw[2], "Ruby 3.0+: positional Hash stays in args slot"
+        assert_equal({}, raw[3], "Ruby 3.0+: kwargs slot is empty")
+      else
+        assert_equal [], raw[2], "Ruby 2.7: trailing Hash auto-promoted out of args"
+        assert_equal({color: :blue}, raw[3], "Ruby 2.7: trailing Hash auto-promoted into kwargs")
+      end
     end
   end
+
+  # =========================================================================
+  # 2. Proxy payload shape — .delay_for and .delay_until
+  # =========================================================================
 
   describe "Proxy payload shape — .delay_for and .delay_until" do
     it "delay_for emits a 4-tuple with kwargs" do
@@ -171,7 +241,8 @@ describe "Proxy kwargs fix (4-tuple payload)" do
       assert_equal 1, ss.size
       raw = ::YAML.unsafe_load(ss.first["args"].first)
       assert_equal 4, raw.length
-      # Only explicitly-passed kwargs are in the payload; kw_b default is applied at dispatch.
+      # Only explicitly-passed kwargs are captured; kw_b's default is applied
+      # at dispatch time, not at enqueue time.
       assert_equal({kw_a: :x}, raw[3])
     end
 
@@ -186,7 +257,7 @@ describe "Proxy kwargs fix (4-tuple payload)" do
   end
 
   # =========================================================================
-  # 4. Module target
+  # 3. Module target (non-class)
   # =========================================================================
 
   describe "Module target (non-class)" do
@@ -209,7 +280,7 @@ describe "Proxy kwargs fix (4-tuple payload)" do
   end
 
   # =========================================================================
-  # 5. YAML symbol key round-trip
+  # 4. YAML symbol key round-trip
   # =========================================================================
 
   describe "YAML symbol key round-trip" do
@@ -231,8 +302,8 @@ describe "Proxy kwargs fix (4-tuple payload)" do
     end
 
     it "symbol keys dispatch correctly after YAML round-trip (**kwargs splat)" do
-      # This is the core correctness guarantee: if keys were stringified by YAML,
-      # **kwargs dispatch would raise ArgumentError.
+      # If keys were stringified by YAML, **kwargs dispatch would raise
+      # ArgumentError.  This is the core correctness guarantee.
       yml = canonical_4tuple_yml(KwargsTarget, :mixed, ["a", "b"], {kw_a: :x, kw_b: :y})
       result = Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
       assert_equal ["a", "b", :x, :y], result, "symbol-keyed kwargs must dispatch without ArgumentError"
@@ -240,7 +311,7 @@ describe "Proxy kwargs fix (4-tuple payload)" do
   end
 
   # =========================================================================
-  # 6. GenericJob#perform dispatch
+  # 5. GenericJob#perform dispatch from 4-tuple payload
   # =========================================================================
 
   describe "GenericJob#perform dispatch from 4-tuple payload" do
@@ -268,10 +339,15 @@ describe "Proxy kwargs fix (4-tuple payload)" do
       yml = canonical_4tuple_yml(KwargsTarget, :splat_kwargs, ["x", "y"], {flag: true})
       assert_equal [["x", "y"], {flag: true}], Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
     end
+
+    it "dispatches no-args, no-kwargs methods" do
+      yml = canonical_4tuple_yml(KwargsTarget, :no_args, [], {})
+      assert_equal :called_without_args, Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
+    end
   end
 
   # =========================================================================
-  # 7. display_class
+  # 6. display_class with 4-tuple payload
   # =========================================================================
 
   describe "display_class with 4-tuple payload" do
@@ -289,7 +365,7 @@ describe "Proxy kwargs fix (4-tuple payload)" do
   end
 
   # =========================================================================
-  # 8. display_args
+  # 7. display_args with 4-tuple payload
   # =========================================================================
 
   describe "display_args with 4-tuple payload" do
@@ -313,7 +389,7 @@ describe "Proxy kwargs fix (4-tuple payload)" do
   end
 
   # =========================================================================
-  # 9. Full round-trip (Proxy → inline GenericJob)
+  # 8. Full round-trip (Proxy → inline GenericJob)
   # =========================================================================
 
   describe "full round-trip via inline testing mode" do
@@ -352,13 +428,12 @@ describe "Proxy kwargs fix (4-tuple payload)" do
   end
 
   # =========================================================================
-  # 10. DelayedModel
+  # 9. DelayedModel — class-method and AR-instance-method paths
   # =========================================================================
 
-  describe "DelayedModel (AR model subclass of GenericJob)" do
+  describe "DelayedModel — class-method path" do
     it "emits a 4-tuple when delay is called on an AR-like class" do
       q = Sidekiq::Queue.new
-      # Use the DelayedModel job class explicitly via the client_push path
       proxy = Sidekiq::DelayExtensions::Proxy.new(
         Sidekiq::DelayExtensions::DelayedModel, KwargsRecord
       )
@@ -384,8 +459,37 @@ describe "Proxy kwargs fix (4-tuple payload)" do
     end
   end
 
+  describe "DelayedModel — AR-instance-method path (production usage shape)" do
+    # In production, delay_extensions wires Sidekiq::DelayExtensions::ActiveRecord
+    # onto ActiveRecord::Base via ActiveSupport.on_load(:active_record).  Each AR
+    # instance gains #delay / #delay_for / #delay_until methods that target the
+    # instance.  This test exercises that exact path with kwargs.
+
+    it "instance.delay.method(kwarg: val) emits a 4-tuple targeting the instance" do
+      q = Sidekiq::Queue.new
+      instance = KwargsActiveModel.new
+      instance.delay.update_with(new_status: :active, audited_by: :sso)
+      raw = ::YAML.unsafe_load(q.first["args"].first)
+      assert_equal 4, raw.length
+      assert_kind_of KwargsActiveModel, raw[0], "instance must be the target slot"
+      assert_equal :update_with, raw[1]
+      assert_equal [], raw[2]
+      assert_equal({new_status: :active, audited_by: :sso}, raw[3])
+    end
+
+    it "instance.delay round-trips kwargs through inline dispatch" do
+      require "sidekiq/delay_extensions/testing"
+      Sidekiq::Testing.inline!
+      instance = KwargsActiveModel.new
+      instance.delay.update_with(new_status: :active, audited_by: :sso)
+      assert_equal({new_status: :active, audited_by: :sso}, KwargsActiveModel.received)
+    ensure
+      Sidekiq::Testing.disable!
+    end
+  end
+
   # =========================================================================
-  # 11. DelayedMailer
+  # 10. DelayedMailer — emission + dispatch with captured kwargs assertion
   # =========================================================================
 
   describe "DelayedMailer (mailer subclass of GenericJob)" do
@@ -400,19 +504,19 @@ describe "Proxy kwargs fix (4-tuple payload)" do
       assert_equal({name: "carol", locale: :fr}, raw[3])
     end
 
-    it "does not raise ArgumentError when kwargs are supplied via 4-tuple on perform" do
+    it "dispatches kwargs to the mailer method (asserted via captured args)" do
+      # KwargsMailer#welcome stores its received kwargs in KwargsMailer.captured_args.
+      # If the kwargs aren't re-splatted correctly, the method either raises
+      # ArgumentError before capture or captures the wrong values.  Either way
+      # the assertion below catches it — no silent vacuous pass.
       yml = canonical_4tuple_yml(KwargsMailer, :welcome, [], {name: "carol", locale: :fr})
-      begin
-        Sidekiq::DelayExtensions::DelayedMailer.new.perform(yml)
-      rescue => e
-        refute_match(/wrong number of arguments/, e.message,
-          "kwargs mismatch ArgumentError must not occur — got: #{e.message}")
-      end
+      Sidekiq::DelayExtensions::DelayedMailer.new.perform(yml)
+      assert_equal({name: "carol", locale: :fr}, KwargsMailer.captured_args)
     end
   end
 
   # =========================================================================
-  # 12. Sidekiq 6.4 built-in payload compatibility
+  # 11. Sidekiq 6.4 built-in payload compatibility
   # =========================================================================
   #
   # Any job enqueued by Sidekiq 6.4's built-in delay extension and still
@@ -421,8 +525,8 @@ describe "Proxy kwargs fix (4-tuple payload)" do
 
   describe "Sidekiq 6.4 built-in payload compatibility" do
     it "dispatches a 6.4-style 4-tuple payload with symbol kwargs" do
-      # Replicate the exact YAML that sidekiq-6.4.0 lib/sidekiq/extensions/generic_proxy.rb
-      # would produce: [target, method_sym, positional_args, kwargs_hash]
+      # Replicates sidekiq-6.4.0 lib/sidekiq/extensions/generic_proxy.rb:
+      #   obj = [@target, name, args, kwargs]
       sidekiq_64_yml = ::YAML.dump([KwargsTarget, :mixed, ["a", "b"], {kw_a: :x, kw_b: :y}])
       result = Sidekiq::DelayExtensions::DelayedClass.new.perform(sidekiq_64_yml)
       assert_equal ["a", "b", :x, :y], result
@@ -442,7 +546,7 @@ describe "Proxy kwargs fix (4-tuple payload)" do
   end
 
   # =========================================================================
-  # 13. Regression scenario — exact broken call from discussion #6979
+  # 12. Regression — discussion #6979 exact repro
   # =========================================================================
   #
   # The reporter called User.delay.call('1', hello: 'there') and got:
@@ -454,11 +558,9 @@ describe "Proxy kwargs fix (4-tuple payload)" do
       q = Sidekiq::Queue.new
       KwargsTarget.delay.call("1", hello: "there")
       raw = ::YAML.unsafe_load(q.first["args"].first)
-      assert_equal 4, raw.length,
-        "broken 7.1.0 produced a 3-tuple — must be 4-tuple now"
+      assert_equal 4, raw.length, "broken 7.1.0 produced a 3-tuple — must be 4-tuple now"
       assert_equal ["1"], raw[2], "positional args must be in slot 2"
-      assert_equal({hello: "there"}, raw[3], "kwargs must be in slot 3, not folded into args"
-      )
+      assert_equal({hello: "there"}, raw[3], "kwargs must be in slot 3, not folded into args")
     end
 
     it "dispatches without ArgumentError for the #6979 call pattern" do
@@ -475,60 +577,67 @@ describe "Proxy kwargs fix (4-tuple payload)" do
       # Manually construct what Sidekiq 6.4 built-in generic_proxy.rb:22 produced:
       #   obj = [@target, name, args, kwargs]
       expected = [KwargsTarget, :call, ["1"], {hello: "there"}]
-      assert_equal expected, gem_payload,
-        "gem 7.2.0 payload must be identical to Sidekiq 6.4 built-in payload"
+      assert_equal expected, gem_payload, "gem 7.2.0 payload must be identical to Sidekiq 6.4 built-in payload"
     end
   end
 
   # =========================================================================
-  # 14. Backward compatibility — legacy 3-tuple payloads
+  # 13. Backward compatibility — legacy 3-tuple payloads
   # =========================================================================
   #
   # Jobs enqueued by gem 7.0–7.1 on Ruby 3.1 are 3-tuples with kwargs folded
   # into args.  After upgrading to 7.2.0, those payloads are still in the
-  # queue.  The fix must not introduce any NEW exception for those jobs.
+  # queue.  The fix must not introduce any NEW exception for those jobs —
+  # dispatch behaviour must be identical to what 7.1.0 produced.
 
   describe "backward compatibility — legacy 3-tuple payloads" do
-    it "pure positional 3-tuple (no kwargs ever involved) dispatches correctly" do
-      yml = ::YAML.dump([KwargsTarget, :positional_only, [5, 6]])
+    it "pure positional 3-tuple (no kwargs ever passed) dispatches correctly" do
+      yml = legacy_3tuple_positional_only(KwargsTarget, :positional_only, [5, 6])
       assert_equal 11, Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
     end
 
-    it "3-tuple with folded kwargs: hash stays positional — no new exception" do
-      yml = legacy_3tuple_yml(KwargsTarget, :splat_kwargs, ["x"], {flag: true})
-      # kwargs slot is absent → treated as {} → dispatched without ** splat.
-      # On Ruby 3.1 the hash stays as a positional element in *args.
+    it "3-tuple with folded kwargs dispatches without raising — version-appropriate result" do
+      # The fix's contract for legacy 3-tuple payloads: do not introduce any new
+      # exception relative to pre-7.2.0.  Final dispatch shape depends on Ruby:
+      #   - Ruby 2.7  → _perform's **kwargs splat auto-promotes the trailing Hash,
+      #                 happily routing the kwargs to the target method (rescue).
+      #   - Ruby 3.0+ → no auto-promotion; the Hash stays positional, matching
+      #                 the broken 7.1.0 dispatch path (no regression).
+      yml = legacy_3tuple_with_folded_kwargs(KwargsTarget, :splat_kwargs, ["x"], {flag: true})
       result = Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
-      assert_equal [["x", {flag: true}], {}], result,
-        "behaviour must be identical to pre-7.2.0: no new exception, hash stays positional"
-    end
-
-    it "3-tuple with empty folded hash dispatches as before (ArgumentError for arity mismatch)" do
-      # The broken proxy emitted an empty {} as a trailing positional arg even
-      # when no kwargs were passed, so positional_only would get 3 args not 2.
-      yml = legacy_3tuple_yml(KwargsTarget, :positional_only, [10, 20], {})
-      assert_raises(ArgumentError) do
-        Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
+      if RUBY_VERSION >= "3.0"
+        assert_equal [["x", {flag: true}], {}], result,
+          "Ruby 3.0+: dispatch identical to pre-7.2.0 (hash stays positional)"
+      else
+        assert_equal [["x"], {flag: true}], result,
+          "Ruby 2.7: language auto-promotion routes folded kwargs to **kwargs"
       end
     end
 
-    it "3-tuple does NOT incorrectly promote the trailing hash to kwargs" do
-      # Heuristic promotion would be wrong for positional-hash methods.
-      yml = legacy_3tuple_yml(KwargsTarget, :splat_kwargs, [], {a: 1})
+    it "the gem adds no heuristic kwargs promotion (delegates entirely to Ruby)" do
+      # The gem must NOT add its own logic to promote a trailing positional
+      # Hash to kwargs — that would be wrong for methods that legitimately
+      # accept a positional Hash.  Whatever happens at dispatch is purely
+      # Ruby's calling convention for the running version.
+      yml = legacy_3tuple_with_folded_kwargs(KwargsTarget, :splat_kwargs, [], {a: 1})
       result = Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
-      # The hash must land in *args, not in **kwargs.
-      assert_equal [[{a: 1}], {}], result,
-        "legacy 3-tuple trailing hash must NOT be promoted to **kwargs"
+      if RUBY_VERSION >= "3.0"
+        assert_equal [[{a: 1}], {}], result,
+          "Ruby 3.0+: no auto-promotion; trailing Hash stays positional in *args"
+      else
+        assert_equal [[], {a: 1}], result,
+          "Ruby 2.7: language-level auto-promotion routes the Hash to **kwargs"
+      end
     end
   end
 
   # =========================================================================
-  # 15. GenericProxy (use_generic_proxy=true) — unchanged
+  # 14. GenericProxy (use_generic_proxy=true) — unchanged
   # =========================================================================
 
   describe "GenericProxy path (use_generic_proxy=true) is unaffected" do
     before { Sidekiq::DelayExtensions.use_generic_proxy = true }
-    after  { Sidekiq::DelayExtensions.use_generic_proxy = false }
+    after { Sidekiq::DelayExtensions.use_generic_proxy = false }
 
     it "still emits a 3-element JSON array (not YAML 4-tuple)" do
       q = Sidekiq::Queue.new

--- a/test/kwargs_proxy_test.rb
+++ b/test/kwargs_proxy_test.rb
@@ -1,0 +1,552 @@
+# frozen_string_literal: true
+
+# Tests for the Proxy 4-tuple kwargs fix (introduced in 7.2.0).
+#
+# Background
+# ----------
+# Sidekiq 6.4's built-in delay Proxy always emitted a 4-tuple YAML payload:
+#   [target, method_name, positional_args, kwargs]
+#
+# sidekiq-delay_extensions 7.0–7.1 regressed to a 3-tuple because
+# Proxy#method_missing lacked the **kwargs parameter.  On Ruby 3.1+, keyword
+# arguments no longer auto-promote from a trailing positional Hash, so a call
+# like User.delay.call("1", hello: :world) collapsed {hello: :world} into
+# *args, producing:
+#   [target, method_name, ["1", {hello: :world}]]   # kwargs silently lost
+#
+# That causes ArgumentError on dispatch for any method with named kwargs.
+# See https://github.com/sidekiq/sidekiq/discussions/6979 for the full report.
+#
+# Coverage in this file
+# ---------------------
+#  1.  Proxy payload shape  — 4-tuple emitted for delay / delay_for / delay_until
+#  2.  Payload slots         — target, method, args, kwargs each in the right slot
+#  3.  Edge cases            — kwargs-only, positional-only, positional Hash ≠ kwargs
+#  4.  Module target         — Proxy works on plain modules, not just classes
+#  5.  YAML symbol round-trip — kwargs keys survive serialisation as symbols
+#  6.  GenericJob dispatch   — perform re-splats kwargs correctly from 4-tuple
+#  7.  dispatch_class        — display_class is correct with 4-tuple payload
+#  8.  display_args          — positional/kwargs shown separately when kwargs present
+#  9.  Full round-trip        — enqueue via Proxy, execute inline via GenericJob
+# 10.  DelayedModel          — all three job subclasses exercised
+# 11.  DelayedMailer         — mailer 4-tuple emission + dispatch without ArgumentError
+# 12.  Sidekiq 6.4 compat    — exact 4-tuple YAML from the old built-in dispatches OK
+# 13.  Regression scenario   — exact broken call from discussion #6979
+# 14.  Backward compat       — legacy 3-tuple payloads dispatched without new exceptions
+# 15.  GenericProxy unchanged — use_generic_proxy=true path is unaffected
+
+require_relative "helper"
+require "sidekiq/api"
+require "active_record"
+require "action_mailer"
+Sidekiq::DelayExtensions.enable_delay!
+
+# ---------------------------------------------------------------------------
+# Support classes
+# ---------------------------------------------------------------------------
+
+class KwargsTarget
+  def self.mixed(pos_a, pos_b, kw_a:, kw_b: :default)
+    [pos_a, pos_b, kw_a, kw_b]
+  end
+
+  def self.kwargs_only(name:, value:)
+    {name: name, value: value}
+  end
+
+  def self.positional_only(a, b)
+    a + b
+  end
+
+  # A positional Hash parameter — must NOT be treated as kwargs at enqueue time.
+  def self.positional_hash(opts = {})
+    opts
+  end
+
+  # Closest real-world pattern: splat + double-splat
+  def self.splat_kwargs(*args, **kwargs)
+    [args, kwargs]
+  end
+
+  # Exact method shape from discussion #6979
+  def self.call(id, hello:)
+    {id: id, hello: hello}
+  end
+end
+
+module KwargsModule
+  def self.compute(factor:, base: 10)
+    base * factor
+  end
+end
+
+class KwargsMailer < ActionMailer::Base
+  def welcome(name:, locale: :en)
+    name
+  end
+end
+
+# Minimal AR-like class for DelayedModel tests (avoids sqlite3 setup)
+class KwargsRecord
+  def self.process(entity_id, action:, priority: :normal)
+    [entity_id, action, priority]
+  end
+end
+
+# ---------------------------------------------------------------------------
+# YAML helpers
+# ---------------------------------------------------------------------------
+
+# 3-tuple YAML as the broken 7.1.0 Proxy emitted on Ruby 3.1 when called with
+# keyword arguments — kwargs are folded as a trailing element of *args.
+def legacy_3tuple_yml(target, method_sym, positional_args, kwargs_hash)
+  ::YAML.dump([target, method_sym, positional_args + [kwargs_hash]])
+end
+
+# 4-tuple YAML as the fixed 7.2.0 Proxy (and Sidekiq 6.4 built-in) emits.
+def canonical_4tuple_yml(target, method_sym, positional_args, kwargs_hash)
+  ::YAML.dump([target, method_sym, positional_args, kwargs_hash])
+end
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+describe "Proxy kwargs fix (4-tuple payload)" do
+  before do
+    @cfg = reset!
+    Sidekiq::DelayExtensions.use_generic_proxy = false
+  end
+
+  after do
+    Sidekiq::DelayExtensions.use_generic_proxy = false
+  end
+
+  # =========================================================================
+  # 1–4. Proxy payload shape
+  # =========================================================================
+
+  describe "Proxy payload shape — .delay" do
+    it "emits a 4-tuple with kwargs in their own slot" do
+      q = Sidekiq::Queue.new
+      KwargsTarget.delay.mixed("a", "b", kw_a: :x, kw_b: :y)
+      raw = ::YAML.unsafe_load(q.first["args"].first)
+      assert_equal 4, raw.length, "expected [target, method, args, kwargs]"
+      assert_equal KwargsTarget, raw[0]
+      assert_equal :mixed, raw[1]
+      assert_equal ["a", "b"], raw[2]
+      assert_equal({kw_a: :x, kw_b: :y}, raw[3])
+    end
+
+    it "emits a 4-tuple when no kwargs given (empty kwargs slot)" do
+      q = Sidekiq::Queue.new
+      KwargsTarget.delay.positional_only(1, 2)
+      raw = ::YAML.unsafe_load(q.first["args"].first)
+      assert_equal 4, raw.length
+      assert_equal [1, 2], raw[2]
+      assert_equal({}, raw[3])
+    end
+
+    it "emits kwargs-only as [] args + kwargs hash" do
+      q = Sidekiq::Queue.new
+      KwargsTarget.delay.kwargs_only(name: "alice", value: 42)
+      raw = ::YAML.unsafe_load(q.first["args"].first)
+      assert_equal [], raw[2]
+      assert_equal({name: "alice", value: 42}, raw[3])
+    end
+
+    it "does not conflate a positional Hash with kwargs" do
+      q = Sidekiq::Queue.new
+      KwargsTarget.delay.positional_hash({color: :blue})
+      raw = ::YAML.unsafe_load(q.first["args"].first)
+      assert_equal [{color: :blue}], raw[2], "positional hash must stay in args slot"
+      assert_equal({}, raw[3], "kwargs slot must be empty")
+    end
+  end
+
+  describe "Proxy payload shape — .delay_for and .delay_until" do
+    it "delay_for emits a 4-tuple with kwargs" do
+      ss = Sidekiq::ScheduledSet.new
+      KwargsTarget.delay_for(5.minutes).mixed("a", "b", kw_a: :x)
+      assert_equal 1, ss.size
+      raw = ::YAML.unsafe_load(ss.first["args"].first)
+      assert_equal 4, raw.length
+      # Only explicitly-passed kwargs are in the payload; kw_b default is applied at dispatch.
+      assert_equal({kw_a: :x}, raw[3])
+    end
+
+    it "delay_until emits a 4-tuple with kwargs" do
+      ss = Sidekiq::ScheduledSet.new
+      KwargsTarget.delay_until(1.hour.from_now).kwargs_only(name: "bob", value: 7)
+      assert_equal 1, ss.size
+      raw = ::YAML.unsafe_load(ss.first["args"].first)
+      assert_equal 4, raw.length
+      assert_equal({name: "bob", value: 7}, raw[3])
+    end
+  end
+
+  # =========================================================================
+  # 4. Module target
+  # =========================================================================
+
+  describe "Module target (non-class)" do
+    it "emits a 4-tuple when delay is called on a module" do
+      q = Sidekiq::Queue.new
+      KwargsModule.delay.compute(factor: 3, base: 5)
+      raw = ::YAML.unsafe_load(q.first["args"].first)
+      assert_equal 4, raw.length
+      assert_equal KwargsModule, raw[0]
+      assert_equal :compute, raw[1]
+      assert_equal [], raw[2]
+      assert_equal({factor: 3, base: 5}, raw[3])
+    end
+
+    it "dispatches module kwargs correctly via GenericJob#perform" do
+      yml = canonical_4tuple_yml(KwargsModule, :compute, [], {factor: 4, base: 3})
+      result = Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
+      assert_equal 12, result
+    end
+  end
+
+  # =========================================================================
+  # 5. YAML symbol key round-trip
+  # =========================================================================
+
+  describe "YAML symbol key round-trip" do
+    it "preserves symbol keys through YAML dump/unsafe_load" do
+      q = Sidekiq::Queue.new
+      KwargsTarget.delay.mixed("a", "b", kw_a: :x, kw_b: :y)
+      raw = ::YAML.unsafe_load(q.first["args"].first)
+      kwargs_slot = raw[3]
+      assert kwargs_slot.keys.all? { |k| k.is_a?(Symbol) },
+        "kwargs keys must survive YAML round-trip as symbols, got: #{kwargs_slot.keys.inspect}"
+    end
+
+    it "preserves symbol values through YAML dump/unsafe_load" do
+      q = Sidekiq::Queue.new
+      KwargsTarget.delay.kwargs_only(name: :symbolic_name, value: :symbolic_value)
+      raw = ::YAML.unsafe_load(q.first["args"].first)
+      assert_equal :symbolic_name, raw[3][:name]
+      assert_equal :symbolic_value, raw[3][:value]
+    end
+
+    it "symbol keys dispatch correctly after YAML round-trip (**kwargs splat)" do
+      # This is the core correctness guarantee: if keys were stringified by YAML,
+      # **kwargs dispatch would raise ArgumentError.
+      yml = canonical_4tuple_yml(KwargsTarget, :mixed, ["a", "b"], {kw_a: :x, kw_b: :y})
+      result = Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
+      assert_equal ["a", "b", :x, :y], result, "symbol-keyed kwargs must dispatch without ArgumentError"
+    end
+  end
+
+  # =========================================================================
+  # 6. GenericJob#perform dispatch
+  # =========================================================================
+
+  describe "GenericJob#perform dispatch from 4-tuple payload" do
+    it "re-splats mixed positional + keyword args" do
+      yml = canonical_4tuple_yml(KwargsTarget, :mixed, ["a", "b"], {kw_a: :x, kw_b: :y})
+      assert_equal ["a", "b", :x, :y], Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
+    end
+
+    it "uses method default when a kwarg is absent from the payload" do
+      yml = canonical_4tuple_yml(KwargsTarget, :mixed, ["a", "b"], {kw_a: :x})
+      assert_equal ["a", "b", :x, :default], Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
+    end
+
+    it "dispatches kwargs-only methods" do
+      yml = canonical_4tuple_yml(KwargsTarget, :kwargs_only, [], {name: "alice", value: 42})
+      assert_equal({name: "alice", value: 42}, Sidekiq::DelayExtensions::DelayedClass.new.perform(yml))
+    end
+
+    it "dispatches positional-only methods (empty kwargs slot)" do
+      yml = canonical_4tuple_yml(KwargsTarget, :positional_only, [3, 4], {})
+      assert_equal 7, Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
+    end
+
+    it "dispatches splat+double-splat methods" do
+      yml = canonical_4tuple_yml(KwargsTarget, :splat_kwargs, ["x", "y"], {flag: true})
+      assert_equal [["x", "y"], {flag: true}], Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
+    end
+  end
+
+  # =========================================================================
+  # 7. display_class
+  # =========================================================================
+
+  describe "display_class with 4-tuple payload" do
+    it "shows 'ClassName.method_name' for class targets" do
+      q = Sidekiq::Queue.new
+      KwargsTarget.delay.mixed("a", "b", kw_a: :x)
+      assert_equal "KwargsTarget.mixed", q.first.display_class
+    end
+
+    it "shows 'ModuleName.method_name' for module targets" do
+      q = Sidekiq::Queue.new
+      KwargsModule.delay.compute(factor: 2)
+      assert_equal "KwargsModule.compute", q.first.display_class
+    end
+  end
+
+  # =========================================================================
+  # 8. display_args
+  # =========================================================================
+
+  describe "display_args with 4-tuple payload" do
+    it "returns flat positional array when kwargs slot is empty" do
+      q = Sidekiq::Queue.new
+      KwargsTarget.delay.positional_only(7, 8)
+      assert_equal [7, 8], q.first.display_args
+    end
+
+    it "returns [positional_args, kwargs_hash] when kwargs are present" do
+      q = Sidekiq::Queue.new
+      KwargsTarget.delay.mixed("p", "q", kw_a: :one, kw_b: :two)
+      assert_equal [["p", "q"], {kw_a: :one, kw_b: :two}], q.first.display_args
+    end
+
+    it "returns [[], kwargs_hash] for kwargs-only calls" do
+      q = Sidekiq::Queue.new
+      KwargsTarget.delay.kwargs_only(name: "dan", value: 0)
+      assert_equal [[], {name: "dan", value: 0}], q.first.display_args
+    end
+  end
+
+  # =========================================================================
+  # 9. Full round-trip (Proxy → inline GenericJob)
+  # =========================================================================
+
+  describe "full round-trip via inline testing mode" do
+    before do
+      require "sidekiq/delay_extensions/testing"
+      Sidekiq::Testing.inline!
+    end
+
+    after { Sidekiq::Testing.disable! }
+
+    it "round-trips mixed positional + keyword args without loss" do
+      result = nil
+      KwargsTarget.stub(:mixed, ->(pos_a, pos_b, kw_a:, kw_b: :default) {
+        result = [pos_a, pos_b, kw_a, kw_b]
+      }) do
+        KwargsTarget.delay.mixed("hello", "world", kw_a: :foo, kw_b: :bar)
+      end
+      assert_equal ["hello", "world", :foo, :bar], result
+    end
+
+    it "round-trips kwargs-only without loss" do
+      result = nil
+      KwargsTarget.stub(:kwargs_only, ->(name:, value:) { result = {name: name, value: value} }) do
+        KwargsTarget.delay.kwargs_only(name: "bob", value: 99)
+      end
+      assert_equal({name: "bob", value: 99}, result)
+    end
+
+    it "round-trips a no-kwargs call (positional only) without loss" do
+      result = nil
+      KwargsTarget.stub(:positional_only, ->(a, b) { result = a + b }) do
+        KwargsTarget.delay.positional_only(10, 32)
+      end
+      assert_equal 42, result
+    end
+  end
+
+  # =========================================================================
+  # 10. DelayedModel
+  # =========================================================================
+
+  describe "DelayedModel (AR model subclass of GenericJob)" do
+    it "emits a 4-tuple when delay is called on an AR-like class" do
+      q = Sidekiq::Queue.new
+      # Use the DelayedModel job class explicitly via the client_push path
+      proxy = Sidekiq::DelayExtensions::Proxy.new(
+        Sidekiq::DelayExtensions::DelayedModel, KwargsRecord
+      )
+      proxy.process(42, action: :archive, priority: :high)
+      raw = ::YAML.unsafe_load(q.first["args"].first)
+      assert_equal 4, raw.length
+      assert_equal KwargsRecord, raw[0]
+      assert_equal :process, raw[1]
+      assert_equal [42], raw[2]
+      assert_equal({action: :archive, priority: :high}, raw[3])
+    end
+
+    it "dispatches kwargs correctly via DelayedModel#perform" do
+      yml = canonical_4tuple_yml(KwargsRecord, :process, [42], {action: :archive, priority: :high})
+      result = Sidekiq::DelayExtensions::DelayedModel.new.perform(yml)
+      assert_equal [42, :archive, :high], result
+    end
+
+    it "dispatches with default kwarg when optional kwarg omitted" do
+      yml = canonical_4tuple_yml(KwargsRecord, :process, [7], {action: :sync})
+      result = Sidekiq::DelayExtensions::DelayedModel.new.perform(yml)
+      assert_equal [7, :sync, :normal], result
+    end
+  end
+
+  # =========================================================================
+  # 11. DelayedMailer
+  # =========================================================================
+
+  describe "DelayedMailer (mailer subclass of GenericJob)" do
+    it "emits a 4-tuple for mailer delay calls" do
+      q = Sidekiq::Queue.new
+      KwargsMailer.delay.welcome(name: "carol", locale: :fr)
+      raw = ::YAML.unsafe_load(q.first["args"].first)
+      assert_equal 4, raw.length
+      assert_equal KwargsMailer, raw[0]
+      assert_equal :welcome, raw[1]
+      assert_equal [], raw[2]
+      assert_equal({name: "carol", locale: :fr}, raw[3])
+    end
+
+    it "does not raise ArgumentError when kwargs are supplied via 4-tuple on perform" do
+      yml = canonical_4tuple_yml(KwargsMailer, :welcome, [], {name: "carol", locale: :fr})
+      begin
+        Sidekiq::DelayExtensions::DelayedMailer.new.perform(yml)
+      rescue => e
+        refute_match(/wrong number of arguments/, e.message,
+          "kwargs mismatch ArgumentError must not occur — got: #{e.message}")
+      end
+    end
+  end
+
+  # =========================================================================
+  # 12. Sidekiq 6.4 built-in payload compatibility
+  # =========================================================================
+  #
+  # Any job enqueued by Sidekiq 6.4's built-in delay extension and still
+  # sitting in the queue / retry set at deploy time must dispatch correctly
+  # with 7.2.0.  The 6.4 built-in used the same 4-tuple format.
+
+  describe "Sidekiq 6.4 built-in payload compatibility" do
+    it "dispatches a 6.4-style 4-tuple payload with symbol kwargs" do
+      # Replicate the exact YAML that sidekiq-6.4.0 lib/sidekiq/extensions/generic_proxy.rb
+      # would produce: [target, method_sym, positional_args, kwargs_hash]
+      sidekiq_64_yml = ::YAML.dump([KwargsTarget, :mixed, ["a", "b"], {kw_a: :x, kw_b: :y}])
+      result = Sidekiq::DelayExtensions::DelayedClass.new.perform(sidekiq_64_yml)
+      assert_equal ["a", "b", :x, :y], result
+    end
+
+    it "dispatches a 6.4-style payload for kwargs-only methods" do
+      sidekiq_64_yml = ::YAML.dump([KwargsTarget, :kwargs_only, [], {name: "migration", value: 1}])
+      result = Sidekiq::DelayExtensions::DelayedClass.new.perform(sidekiq_64_yml)
+      assert_equal({name: "migration", value: 1}, result)
+    end
+
+    it "dispatches a 6.4-style payload for positional-only methods" do
+      sidekiq_64_yml = ::YAML.dump([KwargsTarget, :positional_only, [5, 6], {}])
+      result = Sidekiq::DelayExtensions::DelayedClass.new.perform(sidekiq_64_yml)
+      assert_equal 11, result
+    end
+  end
+
+  # =========================================================================
+  # 13. Regression scenario — exact broken call from discussion #6979
+  # =========================================================================
+  #
+  # The reporter called User.delay.call('1', hello: 'there') and got:
+  #   ArgumentError: wrong number of arguments (given 3, expected 2)
+  #   from generic_job.rb:48 in `_perform'
+
+  describe "regression — discussion #6979 exact repro" do
+    it "enqueues the correct 4-tuple for User.delay.call('1', hello: 'there')" do
+      q = Sidekiq::Queue.new
+      KwargsTarget.delay.call("1", hello: "there")
+      raw = ::YAML.unsafe_load(q.first["args"].first)
+      assert_equal 4, raw.length,
+        "broken 7.1.0 produced a 3-tuple — must be 4-tuple now"
+      assert_equal ["1"], raw[2], "positional args must be in slot 2"
+      assert_equal({hello: "there"}, raw[3], "kwargs must be in slot 3, not folded into args"
+      )
+    end
+
+    it "dispatches without ArgumentError for the #6979 call pattern" do
+      yml = canonical_4tuple_yml(KwargsTarget, :call, ["1"], {hello: "there"})
+      result = Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
+      assert_equal({id: "1", hello: "there"}, result)
+    end
+
+    it "produces the SAME payload shape as Sidekiq 6.4 built-in for the #6979 pattern" do
+      q = Sidekiq::Queue.new
+      KwargsTarget.delay.call("1", hello: "there")
+      gem_payload = ::YAML.unsafe_load(q.first["args"].first)
+
+      # Manually construct what Sidekiq 6.4 built-in generic_proxy.rb:22 produced:
+      #   obj = [@target, name, args, kwargs]
+      expected = [KwargsTarget, :call, ["1"], {hello: "there"}]
+      assert_equal expected, gem_payload,
+        "gem 7.2.0 payload must be identical to Sidekiq 6.4 built-in payload"
+    end
+  end
+
+  # =========================================================================
+  # 14. Backward compatibility — legacy 3-tuple payloads
+  # =========================================================================
+  #
+  # Jobs enqueued by gem 7.0–7.1 on Ruby 3.1 are 3-tuples with kwargs folded
+  # into args.  After upgrading to 7.2.0, those payloads are still in the
+  # queue.  The fix must not introduce any NEW exception for those jobs.
+
+  describe "backward compatibility — legacy 3-tuple payloads" do
+    it "pure positional 3-tuple (no kwargs ever involved) dispatches correctly" do
+      yml = ::YAML.dump([KwargsTarget, :positional_only, [5, 6]])
+      assert_equal 11, Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
+    end
+
+    it "3-tuple with folded kwargs: hash stays positional — no new exception" do
+      yml = legacy_3tuple_yml(KwargsTarget, :splat_kwargs, ["x"], {flag: true})
+      # kwargs slot is absent → treated as {} → dispatched without ** splat.
+      # On Ruby 3.1 the hash stays as a positional element in *args.
+      result = Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
+      assert_equal [["x", {flag: true}], {}], result,
+        "behaviour must be identical to pre-7.2.0: no new exception, hash stays positional"
+    end
+
+    it "3-tuple with empty folded hash dispatches as before (ArgumentError for arity mismatch)" do
+      # The broken proxy emitted an empty {} as a trailing positional arg even
+      # when no kwargs were passed, so positional_only would get 3 args not 2.
+      yml = legacy_3tuple_yml(KwargsTarget, :positional_only, [10, 20], {})
+      assert_raises(ArgumentError) do
+        Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
+      end
+    end
+
+    it "3-tuple does NOT incorrectly promote the trailing hash to kwargs" do
+      # Heuristic promotion would be wrong for positional-hash methods.
+      yml = legacy_3tuple_yml(KwargsTarget, :splat_kwargs, [], {a: 1})
+      result = Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
+      # The hash must land in *args, not in **kwargs.
+      assert_equal [[{a: 1}], {}], result,
+        "legacy 3-tuple trailing hash must NOT be promoted to **kwargs"
+    end
+  end
+
+  # =========================================================================
+  # 15. GenericProxy (use_generic_proxy=true) — unchanged
+  # =========================================================================
+
+  describe "GenericProxy path (use_generic_proxy=true) is unaffected" do
+    before { Sidekiq::DelayExtensions.use_generic_proxy = true }
+    after  { Sidekiq::DelayExtensions.use_generic_proxy = false }
+
+    it "still emits a 3-element JSON array (not YAML 4-tuple)" do
+      q = Sidekiq::Queue.new
+      KwargsTarget.delay.splat_kwargs("a", flag: true)
+      raw = ::JSON.parse(q.first["args"].first)
+      assert_equal 3, raw.length, "GenericProxy always emits a JSON 3-tuple"
+    end
+
+    it "dispatches a 4-tuple payload correctly via the generic proxy perform path" do
+      yml = canonical_4tuple_yml(KwargsTarget, :splat_kwargs, ["a"], {flag: true})
+      result = Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
+      assert_equal [["a"], {flag: true}], result
+    end
+
+    it "dispatches a kwargs-only call via the generic proxy perform path" do
+      yml = canonical_4tuple_yml(KwargsTarget, :kwargs_only, [], {name: "gp", value: 5})
+      result = Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
+      assert_equal({name: "gp", value: 5}, result)
+    end
+  end
+end

--- a/test/testing_extensions_test.rb
+++ b/test/testing_extensions_test.rb
@@ -79,8 +79,11 @@ describe Sidekiq::DelayExtensions do
     assert_equal ["default"], Sidekiq::Queue.all.map(&:name)
     assert_equal 1, q.size
     obj = ::YAML.load q.first["args"].first
-    assert_equal(["argument_a", "argument_b", {with: :keywords}], obj.last)
-    assert_equal(["argument_a", "argument_b", {with: :keywords}], q.first.display_args)
+    # Proxy now emits a 4-tuple [target, method, args, kwargs]; kwargs is the last slot.
+    assert_equal(["argument_a", "argument_b"], obj[2])
+    assert_equal({with: :keywords}, obj[3])
+    # display_args reflects the structured separation: [positional_args, kwargs_hash]
+    assert_equal([["argument_a", "argument_b"], {with: :keywords}], q.first.display_args)
   ensure
     Sidekiq::DelayExtensions.use_generic_proxy = original_use_generic_proxy
   end
@@ -95,8 +98,9 @@ describe Sidekiq::DelayExtensions do
     Sidekiq::DelayExtensions.use_generic_proxy = false
     Sidekiq::Queue.new.clear
 
+    # 4-tuple payload: kwargs are in their own slot and must be re-splatted on dispatch.
     result = Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
-    assert_equal([[], {}], result)
+    assert_equal([[], {with: :keywords}], result)
   ensure
     Sidekiq::DelayExtensions.use_generic_proxy = original_use_generic_proxy
   end
@@ -155,8 +159,9 @@ describe Sidekiq::DelayExtensions do
     assert_equal ["default"], Sidekiq::Queue.all.map(&:name)
     assert_equal 1, q.size
     obj = ::YAML.load q.first["args"].first
-    assert_equal(["argument_a", "argument_b", {with: :keywords}], obj.last)
-    assert_equal(["argument_a", "argument_b", {with: :keywords}], q.first.display_args)
+    assert_equal(["argument_a", "argument_b"], obj[2])
+    assert_equal({with: :keywords}, obj[3])
+    assert_equal([["argument_a", "argument_b"], {with: :keywords}], q.first.display_args)
   ensure
     Sidekiq::DelayExtensions.use_generic_proxy = original_use_generic_proxy
   end
@@ -201,8 +206,9 @@ describe Sidekiq::DelayExtensions do
     SomeClass.delay.doit_with_optional_args("argument_a", "argument_b", with: :keywords)
     assert_equal 1, q.size
     obj = ::YAML.load q.first["args"].first
-    assert_equal(["argument_a", "argument_b", {with: :keywords}], obj.last)
-    assert_equal(["argument_a", "argument_b", {with: :keywords}], q.first.display_args)
+    assert_equal(["argument_a", "argument_b"], obj[2])
+    assert_equal({with: :keywords}, obj[3])
+    assert_equal([["argument_a", "argument_b"], {with: :keywords}], q.first.display_args)
   ensure
     Sidekiq::DelayExtensions.use_generic_proxy = original_use_generic_proxy
   end
@@ -217,7 +223,7 @@ describe Sidekiq::DelayExtensions do
 
     Sidekiq::DelayExtensions.use_generic_proxy = false
     result = Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
-    assert_equal([[], {}], result)
+    assert_equal([[], {with: :keywords}], result)
   ensure
     Sidekiq::DelayExtensions.use_generic_proxy = original_use_generic_proxy
   end
@@ -254,8 +260,9 @@ describe Sidekiq::DelayExtensions do
     SomeModule.delay.doit_with_optional_args("argument_a", "argument_b", with: :keywords)
     assert_equal 1, q.size
     obj = ::YAML.load q.first["args"].first
-    assert_equal(["argument_a", "argument_b", {with: :keywords}], obj.last)
-    assert_equal(["argument_a", "argument_b", {with: :keywords}], q.first.display_args)
+    assert_equal(["argument_a", "argument_b"], obj[2])
+    assert_equal({with: :keywords}, obj[3])
+    assert_equal([["argument_a", "argument_b"], {with: :keywords}], q.first.display_args)
   ensure
     Sidekiq::DelayExtensions.use_generic_proxy = original_use_generic_proxy
   end
@@ -270,7 +277,7 @@ describe Sidekiq::DelayExtensions do
 
     Sidekiq::DelayExtensions.use_generic_proxy = false
     result = Sidekiq::DelayExtensions::DelayedClass.new.perform(yml)
-    assert_equal([[], {}], result)
+    assert_equal([[], {with: :keywords}], result)
   ensure
     Sidekiq::DelayExtensions.use_generic_proxy = original_use_generic_proxy
   end


### PR DESCRIPTION
# Restore 4-tuple kwargs payload (regression from 6.4 → 7.0)

Fixes the `ArgumentError` raised when `delay` is called with keyword arguments on Ruby 3.1+. See [sidekiq#6979](https://github.com/sidekiq/sidekiq/discussions/6979) for the original report.

## The bug

**Sidekiq 6.4 built-in** (`sidekiq-6.4.0/lib/sidekiq/extensions/generic_proxy.rb:16`):

```ruby
def method_missing(name, *args, **kwargs)
  obj = [@target, name, args, kwargs]   # 4-tuple, kwargs in own slot
```

**This gem 7.0.0–7.1.0** (`lib/sidekiq/delay_extensions/generic_proxy.rb:19`):

```ruby
def method_missing(name, *args)         # ← **kwargs missing
  obj = [@target, name, args]           # 3-tuple, kwargs lost
```

On Ruby 3.1+, `User.delay.call("1", hello: "there")` therefore produces:

```yaml
# Sidekiq 6.4 built-in (4-tuple — kwargs in own slot)
- !ruby/class 'User'
- :call
- ['1']
- :hello: there

# This gem 7.1.0 (3-tuple — kwargs silently folded into args)
- !ruby/class 'User'
- :call
- ['1', :hello: there]
```

`GenericJob#perform` then calls `target.__send__(method, *args)`, which on Ruby 3.1+ passes the trailing Hash positionally instead of as kwargs. Real test-suite stack trace from the affected version:

```
ArgumentError: wrong number of arguments (given 3, expected 2)
  sidekiq-delay_extensions-7.1.0/.../generic_job.rb:48:in `_perform'
  sidekiq-delay_extensions-7.1.0/.../generic_job.rb:11:in `perform'
  sidekiq-delay_extensions-7.1.0/.../generic_proxy.rb:30:in `method_missing'
```

## The fix — 21 lines of production code

`Proxy#method_missing` regains the `**kwargs` parameter and emits a 4-tuple identical to Sidekiq 6.4's. `GenericJob#perform` destructures all four slots and re-splats kwargs explicitly on dispatch. `kwargs ||= {}` ensures legacy 3-tuple payloads (already in queue / retry / scheduled at deploy time) dispatch identically to pre-7.2.0 — **no new exceptions** for those jobs.

`GenericProxy` (`use_generic_proxy = true`) is unchanged — it already handled kwargs through its own JSON serialisation path.

## ⚠️ Visible behaviour changes — read before merging

**1. Wire format.** New payloads are 4-tuples. Legacy 3-tuple payloads continue to dispatch correctly with no new exceptions.

**2. `Sidekiq::JobRecord#display_args`** for delay jobs: when kwargs are present, returns `[positional_args, kwargs_hash]` instead of a flat merged array. This *restores* the structured format that `lib/sidekiq/delay_extensions/api.rb` was always written for — that block was effectively dead code while the proxy emitted 3-tuples.

```ruby
# 7.1.0:    job.display_args  #=> ["alice@example.com", {locale: :en}]
# 7.2.0+:   job.display_args  #=> [["alice@example.com"], {locale: :en}]
```

Web UI extensions, log scrapers, and observability dashboards that read `display_args` for delay jobs will need a small update. Detailed in the README.

## Backward compatibility

| Payload source | Ruby 3.0+ on 7.2.0 | Ruby 2.7 on 7.2.0 |
|---|---|---|
| Sidekiq 6.4 built-in (4-tuple) | ✅ Dispatches correctly | ✅ Dispatches correctly |
| Gem 7.2.0 enqueue (4-tuple) | ✅ Dispatches correctly | ✅ Dispatches correctly |
| Gem 7.0–7.1 legacy (3-tuple), no kwargs | ✅ Dispatches correctly | ✅ Dispatches correctly |
| Gem 7.0–7.1 legacy (3-tuple), folded kwargs | ⚠️ Same as pre-7.2.0 (Hash stays positional, dispatch may fail per method arity) | ✅ Ruby 2.7 auto-promotion *recovers* the kwargs |

## Test coverage

`test/kwargs_proxy_test.rb` — **45 tests, 81 assertions, 0 failures** locally.

Covers:

- Payload shape for `delay`, `delay_for`, `delay_until`
- No-args, kwargs-only, positional-only, splat+kwargs combinations
- Module targets and ActiveRecord class & instance methods
- `DelayedMailer` 4-tuple emission and dispatch with captured-kwargs assertion
- YAML symbol-key round-trip (the primary correctness invariant)
- `display_class` and `display_args` correctness
- Full inline round-trip through `Proxy → GenericJob`
- Legacy 3-tuple backward compatibility (no new exceptions)
- `GenericProxy` (`use_generic_proxy=true`) is unaffected
- **Exact wire-format match against Sidekiq 6.4 built-in**
- **Exact regression repro from discussion #6979**

Three tests use version-aware assertions (`if RUBY_VERSION >= "3.0"`) to correctly assert behaviour on every row of the CI matrix — the gem itself is compatible with every supported Ruby; only Ruby's own positional-Hash auto-promotion semantics differ between 2.7 and 3.0+.

## Migration guidance

Detailed in the README's new "Migrating from Sidekiq 6 to 7 (kwargs fix)" section. Three recommended paths:

1. Deploy 7.2.0 — new jobs work; let legacy jobs drain via retries.
2. Drain affected legacy jobs from retry / dead set before deploying.
3. Add server middleware to detect 3-tuple payloads and re-enqueue with corrected kwargs (snippet referenced in #6979).

## Files changed

```
 Changes.md                                    |  64 +++
 README.md                                     | 113 +++++
 lib/sidekiq/delay_extensions/generic_job.rb   |  10 +-
 lib/sidekiq/delay_extensions/generic_proxy.rb |   9 +-
 lib/sidekiq/delay_extensions/version.rb       |   2 +-
 test/kwargs_proxy_test.rb                     | 636 +++++++++++++++++++
 test/testing_extensions_test.rb               |  29 +-
 7 files changed, 847 insertions(+), 16 deletions(-)
```

## Production validation — to follow

I'm rolling this out against our internal stack (Rails 6.1.7.10, Ruby 3.1.5, Sidekiq 7.3.10, Sidekiq Pro 7.3.6) where the original `ArgumentError` surfaced. **I'll post screenshots and integration evidence from that deployment as follow-up comments on this PR** so reviewers can see the fix verified end-to-end in a real production-shape environment, including interaction with Sidekiq Pro batches and our scheduled job set.

Closes [sidekiq#6979](https://github.com/sidekiq/sidekiq/discussions/6979).